### PR TITLE
add inexpensive guess for sysPrefix when withSysPrefix: false

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,7 +24,7 @@ function accessCheck(d) {
 }
 
 function guessSysPrefix() {
-  // inexpensive guess for sysPrefix based on location of `which jupyter`
+  // inexpensive guess for sysPrefix based on location of `which python`
   // based on shutil.which from Python 3.5
 
   // only run once:
@@ -43,10 +43,10 @@ function guessSysPrefix() {
 
   PATH.some(bin => {
     bin = path.resolve(bin);
-    var jupyter = path.join(bin, 'jupyter');
+    var python = path.join(bin, 'python');
 
     return pathext.some(ext => {
-      var exe = jupyter + ext;
+      var exe = python + ext;
       if (accessCheck(exe)) {
         // PREFIX/bin/jupyter exists, return PREFIX
         // following symlinks

--- a/index.js
+++ b/index.js
@@ -48,9 +48,15 @@ function guessSysPrefix() {
     return pathext.some(ext => {
       var exe = python + ext;
       if (accessCheck(exe)) {
-        // PREFIX/bin/jupyter exists, return PREFIX
+        // PREFIX/bin/python exists, return PREFIX
         // following symlinks
-        sysPrefixGuess = path.dirname(path.dirname(fs.realpathSync(exe)));
+        if (process.platform === 'win32') {
+          // Windows: Prefix\Python.exe
+          sysPrefixGuess = path.dirname(fs.realpathSync(exe));
+        } else {
+          // Everywhere else: prefix/bin/python
+          sysPrefixGuess = path.dirname(path.dirname(fs.realpathSync(exe)));
+        }
         return true;
       }
     })

--- a/test/jupyter_paths_spec.js
+++ b/test/jupyter_paths_spec.js
@@ -9,10 +9,15 @@ const execSync = require('child_process').execSync
 
 const actual = JSON.parse(execSync('jupyter --paths --json'))
 
+// case-insensitive comparisons
+actual.data = actual.data.map(path => { return path.toLowerCase(); });
+actual.config = actual.config.map(path => { return path.toLowerCase(); });
+
 describe('dataDirs', () => {
   it('returns a promise that resolves to a list of directories that exist', () => {
     return jp.dataDirs({withSysPrefix: true})
              .then((dirs) => {
+               dirs = dirs.map(dir => { return dir.toLowerCase() });
                expect(dirs).to.be.an('Array')
                dirs.forEach(el => {
                  expect(el).to.be.a('String')
@@ -22,6 +27,7 @@ describe('dataDirs', () => {
   })
   it('returns immediately with a guess when withSysPrefix is false', () => {
     var dirs = jp.dataDirs({withSysPrefix: false});
+    dirs = dirs.map(dir => { return dir.toLowerCase() });
     expect(dirs).to.be.an('Array');
     dirs.forEach(el => {
       expect(el).to.be.a('String')
@@ -40,6 +46,7 @@ describe('configDirs', () => {
   it('returns a promise that resolves to a list of directories that exist', () => {
     return jp.configDirs({withSysPrefix: true})
              .then((dirs) => {
+               dirs = dirs.map(dir => { return dir.toLowerCase() });
                expect(dirs).to.be.an('Array')
                dirs.forEach(el => {
                  expect(el).to.be.a('String')
@@ -49,6 +56,7 @@ describe('configDirs', () => {
   })
   it('returns immediately with a guess when withSysPrefix is false', () => {
     var dirs = jp.configDirs({withSysPrefix: false});
+    dirs = dirs.map(dir => { return dir.toLowerCase() });
     expect(dirs).to.be.an('Array');
     dirs.forEach(el => {
       expect(el).to.be.a('String')

--- a/test/jupyter_paths_spec.js
+++ b/test/jupyter_paths_spec.js
@@ -8,20 +8,25 @@ const home = require('home-dir')
 const execSync = require('child_process').execSync
 
 const actual = JSON.parse(execSync('jupyter --paths --json'))
-actual.data.sort()
-actual.config.sort()
 
 describe('dataDirs', () => {
   it('returns a promise that resolves to a list of directories that exist', () => {
     return jp.dataDirs({withSysPrefix: true})
              .then((dirs) => {
-               dirs.sort()
                expect(dirs).to.be.an('Array')
                dirs.forEach(el => {
                  expect(el).to.be.a('String')
                })
                expect(dirs).to.deep.equal(actual.data)
              })
+  })
+  it('returns immediately with a guess when withSysPrefix is false', () => {
+    var dirs = jp.dataDirs({withSysPrefix: false});
+    expect(dirs).to.be.an('Array');
+    dirs.forEach(el => {
+      expect(el).to.be.a('String')
+    });
+    expect(dirs).to.deep.equal(actual.data);
   })
 })
 
@@ -35,7 +40,6 @@ describe('configDirs', () => {
   it('returns a promise that resolves to a list of directories that exist', () => {
     return jp.configDirs({withSysPrefix: true})
              .then((dirs) => {
-               dirs.sort()
                expect(dirs).to.be.an('Array')
                dirs.forEach(el => {
                  expect(el).to.be.a('String')
@@ -43,4 +47,13 @@ describe('configDirs', () => {
                expect(dirs).to.deep.equal(actual.config)
              })
   })
+  it('returns immediately with a guess when withSysPrefix is false', () => {
+    var dirs = jp.configDirs({withSysPrefix: false});
+    expect(dirs).to.be.an('Array');
+    dirs.forEach(el => {
+      expect(el).to.be.a('String')
+    });
+    expect(dirs).to.deep.equal(actual.config);
+  })
 })
+


### PR DESCRIPTION
effectively does `which jupyter` without instantiating any subprocesses, and resolves `realpath(jupyter)/../..` for the prefix.

I also removed the `sort` calls from the tests, which hid a bug where the ordering of system data dirs was not correct

Tests pass on OS X with conda Python, as well as virtualenvs.

Another option is to check on `python`, rather than `jupyter`. The `realpath` in that case will give the right answer for homebrew Python, which this doesn't (no change from master). The disadvantage is that it will include Python's prefix whether the Jupyter Python package is installed or not, and there isn't a way to identify _which_ Python without reading the shebang line of the Jupyter script, and I wanted to make sure that no files were opened or processes executed.

If Jupyter is installed with `--user`, this will add the user prefix, which is not on the Python implementation's path, so will generally turn up no results.
