### PR TITLE
add askJupyter option

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "mocha": "^2.3.4"
   },
   "dependencies": {
-    "home-dir": "^1.0.0",
-    "sys-prefix-promise": "^1.0.4"
+    "home-dir": "^1.0.0"
   }
 }

--- a/test/jupyter_paths_spec.js
+++ b/test/jupyter_paths_spec.js
@@ -25,6 +25,17 @@ describe('dataDirs', () => {
                expect(dirs).to.deep.equal(actual.data)
              })
   })
+  it('returns a promise that resolves to a list of directories that exist', () => {
+    return jp.dataDirs({askJupyter: true})
+             .then((dirs) => {
+               dirs = dirs.map(dir => { return dir.toLowerCase() });
+               expect(dirs).to.be.an('Array')
+               dirs.forEach(el => {
+                 expect(el).to.be.a('String')
+               })
+               expect(dirs).to.deep.equal(actual.data)
+             })
+  })
   it('returns immediately with a guess when withSysPrefix is false', () => {
     var dirs = jp.dataDirs({withSysPrefix: false});
     dirs = dirs.map(dir => { return dir.toLowerCase() });
@@ -45,6 +56,17 @@ describe('runtimeDir', () => {
 describe('configDirs', () => {
   it('returns a promise that resolves to a list of directories that exist', () => {
     return jp.configDirs({withSysPrefix: true})
+             .then((dirs) => {
+               dirs = dirs.map(dir => { return dir.toLowerCase() });
+               expect(dirs).to.be.an('Array')
+               dirs.forEach(el => {
+                 expect(el).to.be.a('String')
+               })
+               expect(dirs).to.deep.equal(actual.config)
+             })
+  })
+  it('returns a promise that resolves to a list of directories that exist', () => {
+    return jp.configDirs({askJupyter: true})
              .then((dirs) => {
                dirs = dirs.map(dir => { return dir.toLowerCase() });
                expect(dirs).to.be.an('Array')

--- a/test/jupyter_paths_spec.js
+++ b/test/jupyter_paths_spec.js
@@ -36,8 +36,8 @@ describe('dataDirs', () => {
                expect(dirs).to.deep.equal(actual.data)
              })
   })
-  it('returns immediately with a guess when withSysPrefix is false', () => {
-    var dirs = jp.dataDirs({withSysPrefix: false});
+  it('returns immediately with a guess by default', () => {
+    var dirs = jp.dataDirs();
     dirs = dirs.map(dir => { return dir.toLowerCase() });
     expect(dirs).to.be.an('Array');
     dirs.forEach(el => {
@@ -76,8 +76,8 @@ describe('configDirs', () => {
                expect(dirs).to.deep.equal(actual.config)
              })
   })
-  it('returns immediately with a guess when withSysPrefix is false', () => {
-    var dirs = jp.configDirs({withSysPrefix: false});
+  it('returns immediately with a guess by default', () => {
+    var dirs = jp.configDirs();
     dirs = dirs.map(dir => { return dir.toLowerCase() });
     expect(dirs).to.be.an('Array');
     dirs.forEach(el => {


### PR DESCRIPTION
deprecates `withSysPrefix: true` in favor of the good-enough guess based on PATH.

also closes #16

if going with this, can skip #20