### PR TITLE
fix(dataDirs): fix crash when python is not in path

### DIFF
--- a/index.js
+++ b/index.js
@@ -198,9 +198,11 @@ function dataDirs(opts) {
   }
   // inexpensive guess, based on location of `python` executable
   var sysPrefix = guessSysPrefix();
-  var sysPathed = path.join(sysPrefix, 'share', 'jupyter');
-  if (systemDirs.indexOf(sysPathed) === -1) {
-    paths.push(sysPathed);
+  if(sysPrefix) {
+    var sysPathed = path.join(sysPrefix, 'share', 'jupyter');
+    if (systemDirs.indexOf(sysPathed) === -1) {
+      paths.push(sysPathed);
+    }
   }
   return paths.concat(systemDirs);
 }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
   "homepage": "https://github.com/nteract/jupyter-paths",
   "devDependencies": {
     "chai": "^4.0.1",
-    "mocha": "^3.2.0"
+    "mocha": "^3.2.0",
+    "rewire": "^2.5.2"
   },
   "dependencies": {
     "home-dir": "^1.0.0"

--- a/test/jupyter_paths_spec.js
+++ b/test/jupyter_paths_spec.js
@@ -40,7 +40,7 @@ describe('dataDirs', () => {
                  expect(el).to.be.a('String')
                })
                expect(actual.data).to.include.members(dirs)
-               expect(actual.data.length).to.be.greaterThan(dirs.length)
+               expect(actual.data.length).to.not.be.lessThan(dirs.length)
               });
 
     revert();

--- a/test/jupyter_paths_spec.js
+++ b/test/jupyter_paths_spec.js
@@ -1,4 +1,5 @@
-const jp = require('../')
+var rewire = require("rewire");
+const jp = rewire('../')
 
 const expect = require('chai').expect
 
@@ -14,6 +15,8 @@ actual.data = actual.data.map(path => { return path.toLowerCase(); });
 actual.config = actual.config.map(path => { return path.toLowerCase(); });
 
 describe('dataDirs', () => {
+
+
   it('returns a promise that resolves to a list of directories that exist', () => {
     return jp.dataDirs({withSysPrefix: true})
              .then((dirs) => {
@@ -24,6 +27,24 @@ describe('dataDirs', () => {
                })
                expect(dirs).to.deep.equal(actual.data)
              })
+  })
+  it('works even in the absence of python', () => {
+    // mock guessSysPrefix to force it to fail
+    var revert = jp.__set__("guessSysPrefix", () => null);
+
+    var result = jp.dataDirs({withSysPrefix: true})
+             .then((dirs) => {
+               dirs = dirs.map(dir => { return dir.toLowerCase() });
+               expect(dirs).to.be.an('Array')
+               dirs.forEach(el => {
+                 expect(el).to.be.a('String')
+               })
+               expect(actual.data).to.include.members(dirs)
+               expect(actual.data.length).to.be.greaterThan(dirs.length)
+              });
+
+    revert();
+    return result;
   })
   it('returns a promise that resolves to a list of directories that exist', () => {
     return jp.dataDirs({askJupyter: true})


### PR DESCRIPTION
Properly handle the case when `guessSysPrefix` can't find anything (i.e.: when python isn't installed)