### PR TITLE
Replace fs.realpathSync() with path.resolve()

### DIFF
--- a/index.js
+++ b/index.js
@@ -53,13 +53,13 @@ function guessSysPrefix() {
         if (process.platform === "win32") {
           // Windows: Prefix\Python.exe
           try {
-            sysPrefixGuess = path.dirname(fs.realpathSync(exe));
+            sysPrefixGuess = path.dirname(path.resolve(exe));
           } catch {
             sysPrefixGuess = null;
           }
         } else {
           // Everywhere else: prefix/bin/python
-          sysPrefixGuess = path.dirname(path.dirname(fs.realpathSync(exe)));
+          sysPrefixGuess = path.dirname(path.dirname(path.resolve(exe)));
         }
         return true;
       }


### PR DESCRIPTION
Background for this PR can be found in #32.

This PR replaces `fs.realpathSync()` with `path.resolve()`. Both functions can be used to resolve relative paths to absolute paths, but `fs.realpathSync()` additionally resolves symlinks, too.

If the virtualenv was created using symlinks to the OS Python interpreter (the new default in virtualenv >= 20.0.0), this will make this library escape the virtualenv and return incorrect paths for `dataDirs()` and `configDirs()`.

To test this PR, do:

```
virtualenv --symlinks .
ls -l bin/python*                  # make sure you are seeing symlinks

git clone https://github.com/nteract/jupyter-paths.git
cd jupyter-paths

npm install --only=dev

npm test    # this fails

git fetch origin pull/33/head:pr-33
git checkout pr-33
npm test    # this succeeds
```